### PR TITLE
[FEAT] merge taylor cache in generate.py and add config args for taylor cache

### DIFF
--- a/wan/modules/model.py
+++ b/wan/modules/model.py
@@ -8,7 +8,7 @@ from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.models.modeling_utils import ModelMixin
 
 from .attention import flash_attention
-from wan.taylorseer.cache_functions import cache_init
+from wan.taylorseer.cache_functions import cache_init, cache_update
 
 __all__ = ['WanModel']
 
@@ -512,6 +512,12 @@ class WanModel(ModelMixin, ConfigMixin):
 
     def cache_init(self):
         self.cache_dic, self.current = cache_init(self)
+    
+    def cache_update(self, **kwargs):
+        # print("############### kwargs: ",  kwargs)
+        if "max_order" in kwargs or "fresh_threshold" in kwargs:
+            self.cache_dic, self.current = cache_update(self, **kwargs)
+
     def forward(
         self,
         x,
@@ -519,7 +525,8 @@ class WanModel(ModelMixin, ConfigMixin):
         context,
         seq_len,
         clip_fea=None,
-        y=None,
+        y=None
+        # **kwargs
     ):
         r"""
         Forward pass through the diffusion model

--- a/wan/taylorseer/cache_functions/__init__.py
+++ b/wan/taylorseer/cache_functions/__init__.py
@@ -1,3 +1,3 @@
-from .cache_init import cache_init
+from .cache_init import cache_init, cache_update
 from .cal_type import cal_type
 from .force_scheduler import force_scheduler

--- a/wan/taylorseer/cache_functions/cache_init.py
+++ b/wan/taylorseer/cache_functions/cache_init.py
@@ -65,3 +65,72 @@ def cache_init(self, num_steps= 50):
     current['num_steps'] = num_steps
 
     return cache_dic, current
+
+def cache_update(self, num_steps= 50, **kwargs):   
+    '''
+    Initialization for cache.
+    '''
+    cache_dic = {}
+    cache = {}
+    cache[-1]={}
+    cache[-1]['cond_stream']={}
+    cache[-1]['uncond_stream']={}
+    cache_dic['cache_counter'] = 0
+
+    for j in range(self.num_layers):
+        cache[-1]['cond_stream'][j] = {}
+        cache[-1]['uncond_stream'][j] = {}
+
+    cache_dic['taylor_cache'] = False
+    cache_dic['Delta-DiT'] = False
+
+
+    cache_dic['cache_type'] = 'random'
+    cache_dic['fresh_ratio_schedule'] = 'ToCa' 
+    cache_dic['fresh_ratio'] = 0.0
+    cache_dic['fresh_threshold'] = 1
+    cache_dic['force_fresh'] = 'global'
+
+    mode = 'Taylor'
+
+    if mode == 'original':
+        cache_dic['cache'] = cache
+        cache_dic['force_fresh'] = 'global'
+        cache_dic['max_order'] = 0
+        cache_dic['first_enhance'] = 3
+        
+    elif mode == 'ToCa':
+        cache_dic['cache_type'] = 'attention'
+        cache_dic['cache'] = cache
+        cache_dic['fresh_ratio_schedule'] = 'ToCa' 
+        cache_dic['fresh_ratio'] = 0.1
+        cache_dic['fresh_threshold'] = 5
+        cache_dic['force_fresh'] = 'global' 
+        cache_dic['soft_fresh_weight'] = 0.0
+        cache_dic['max_order'] = 0
+        cache_dic['first_enhance'] = 3
+    
+    elif mode == 'Taylor':
+        taylor_max_order = kwargs.get("max_order", 1)
+        taylor_fresh_threshold  = kwargs.get("fresh_threshold", 5)
+        # print("*****************use max_order : {} fresh_threshold : {}".format(taylor_max_order,  taylor_fresh_threshold))
+        cache_dic['cache'] = cache
+        cache_dic['fresh_threshold'] = taylor_fresh_threshold
+        cache_dic['taylor_cache'] = True
+        cache_dic['max_order'] = taylor_max_order
+        cache_dic['first_enhance'] = 1
+
+    elif mode == 'Delta':
+        cache_dic['cache'] = cache
+        cache_dic['fresh_ratio'] = 0.0
+        cache_dic['fresh_threshold'] = 3
+        cache_dic['Delta-DiT'] = True
+        cache_dic['max_order'] = 0
+        cache_dic['first_enhance'] = 1
+
+    current = {}
+    current['activated_steps'] = [0]
+    current['step'] = 0
+    current['num_steps'] = num_steps
+
+    return cache_dic, current


### PR DESCRIPTION
pass    taylor_cache_max_order and taylor_cache_fresh_threshold args when generate vedios, default is 1 and 5
parser.add_argument(
        "--taylor_cache_max_order",
        type=int,
        default= -1,
        help="taylor cache max_order or not"
    )

    parser.add_argument(
        "--taylor_cache_fresh_threshold",
        type=int,
        default= -1,
        help="taylor cache fresh threshold"
    )