### PR TITLE
add option '--enable-sage-attn' to use SageAttention on Ada/Ampere/Ho…

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -843,6 +843,14 @@ def _parse_args():
         help="Use Flash Attention 3 for attention layers or not."
     )
 
+    parser.add_argument(
+        "--enable-sage-attn",
+        "--enable_sage_attn",
+        action="store_true",
+        default=False,
+        help="Use SageAttention for attention layers or not."
+    )
+
     args = parser.parse_args()
 
     _validate_args(args)
@@ -964,12 +972,18 @@ def generate(args):
             t5_fsdp=args.t5_fsdp,
             dit_fsdp=args.dit_fsdp,
             use_usp=(args.ulysses_size > 1 or args.ring_size > 1),
-            t5_cpu=args.t5_cpu, use_taylor_cache= args.enable_taylor_cache
+            t5_cpu=args.t5_cpu,
+            use_taylor_cache=args.enable_taylor_cache,
         )
 
         if args.enable_fa3:
             for block in wan_t2v.model.blocks:
                 block.self_attn.__class__.enable_fa3 = True
+
+        if args.enable_sage_attn:
+            for block in wan_t2v.model.blocks:
+                block.self_attn.__class__.enable_sage_attn = True
+
         
         if args.enable_teacache:
             wan_t2v.__class__.generate = t2v_generate
@@ -1075,6 +1089,11 @@ def generate(args):
         if args.enable_fa3:
             for block in wan_i2v.model.blocks:
                 block.self_attn.__class__.enable_fa3 = True
+
+        if args.enable_sage_attn:
+            for block in wan_i2v.model.blocks:
+                block.self_attn.__class__.enable_sage_attn = True
+
         
         if args.enable_teacache:
             wan_i2v.__class__.generate = i2v_generate

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -38,7 +38,7 @@ class WanT2V:
         dit_fsdp=False,
         use_usp=False,
         t5_cpu=False,
-        use_taylor_cache = False
+        use_taylor_cache=False,
     ):
         r"""
         Initializes the Wan text-to-video generation model components.

--- a/wan/utils/utils.py
+++ b/wan/utils/utils.py
@@ -10,14 +10,6 @@ import torchvision
 
 __all__ = ['cache_video', 'cache_image', 'str2bool']
 
-try:
-    import sageattention
-    HAS_SAGE_ATTENTION = True
-except ImportError:
-    HAS_SAGE_ATTENTION = False
-
-ENABLE_SAGE_ATTENTION = os.environ.get('ENABLE_SAGE_ATTENTION', '0') == '1' and HAS_SAGE_ATTENTION
-
 def rand_name(length=8, suffix=''):
     name = binascii.b2a_hex(os.urandom(length)).decode('utf-8')
     if suffix:


### PR DESCRIPTION
Follow up https://github.com/bytedance-iaas/Wan2.1/pull/10. For now, it is not able to run SageAttention on Ada/Ampere GPU, such as L20, A100 and A800.  
This PR add option `--enable-sage-attn` or `--enable_sage_attn` to use SageAttention on Ada/Ampere/Hopper GPU.

## Prerequisite
Install SageAttention 2.0 from source.
```bash
git clone https://github.com/thu-ml/SageAttention.git
cd SageAttention
python setup.py install
```

## Benchmark
`torchrun --nproc_per_node=8 generate.py --task t2v-14B --size 1280*720 --ckpt_dir ./Wan2.1-T2V-14B --dit_fsdp --t5_fsdp --ulysses_size 8 --prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage." --enable-sage-attn`
| GPU | Model | Resolution | latency(s) | boost |
| ----------- | ----------- | ----------- | ----------- | ----------- |
| 8*H20 | Wan2.1-T2V-14B | 1280 * 720 | 881 (baseline) | - |
| 8*H20 | Wan2.1-T2V-14B | 1280 * 720 | 643 (enable-fa3) | +27.0% |
| 8*H20 | Wan2.1-T2V-14B | 1280 * 720 | 442 (enable-sage-attn)|  +49.7%  |
| 8*L20 | Wan2.1-T2V-14B | 1280 * 720 | 1007 (baseline) | - |
| 8*L20 | Wan2.1-T2V-14B | 1280 * 720 | 764 (enable-sage-attn) | +24.4% |
| 8*A800 | Wan2.1-T2V-14B | 1280 * 720 | 451 (baseline) | - |
| 8*A800 | Wan2.1-T2V-14B | 1280 * 720 | 414 (enable-sage-attn) | +8.2% |
